### PR TITLE
Ensure compatibility with Blesta 5.13.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 name: CI
 
 on:
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron: "0 0 * * *"
   push:
@@ -47,6 +50,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Login to Docker Hub
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v3
         with:
           registry: docker.io
@@ -54,6 +58,7 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
       - name: Login to GitHub Container Registry
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -124,6 +129,7 @@ jobs:
           retention-days: 1
 
       - name: Push image
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/bake-action@v5
         with:
           files: docker-bake.hcl
@@ -134,6 +140,7 @@ jobs:
             docker.io/ppmathis/blesta:<version>
 
       - name: Update Docker Hub description
+        if: ${{ github.event_name != 'pull_request' }}
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "0 0 * * *"
+    - cron: '0 0 * * *'
   push:
     branches:
       - main
@@ -98,7 +98,7 @@ jobs:
           push: true
         env:
           IMAGE_NAMES: localhost:5000/blesta:${{ github.sha }}
-          DOCKER_BUILD_SUMMARY: "false"
+          DOCKER_BUILD_SUMMARY: 'false'
 
       - name: Test image for AMD64
         run: npx playwright test
@@ -147,3 +147,12 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
           repository: ppmathis/blesta
           enable-url-completion: true
+
+  build-status:
+    runs-on: ubuntu-24.04
+    needs:
+      - build
+    if: ${{ always() }}
+    steps:
+      - name: Verify all targets built successfully
+        run: test "${{ needs.build.result }}" = "success"

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,7 @@ RUN true \
   nginx \
   "php${PHP_VERSION}" \
   "php${PHP_VERSION}-curl" \
+  "php${PHP_VERSION}-fileinfo" \
   "php${PHP_VERSION}-fpm" \
   "php${PHP_VERSION}-gd" \
   "php${PHP_VERSION}-gmp" \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -14,7 +14,7 @@ variable "PLATFORMS" {
 variable "VERSIONS" {
   default = [
     { blesta-version = "5.12.5", blesta-download-id = "305", alpine-version = "3.22", php-version = "8.2", extra-tags = [] },
-    { blesta-version = "5.13.9", blesta-download-id = "309", alpine-version = "3.22", php-version = "8.2", extra-tags = ["latest"] },
+    { blesta-version = "5.13.10", blesta-download-id = "312", alpine-version = "3.22", php-version = "8.2", extra-tags = ["latest"] },
   ]
 }
 

--- a/tests/blesta-admin/02-company-emails.spec.ts
+++ b/tests/blesta-admin/02-company-emails.spec.ts
@@ -26,3 +26,16 @@ test.describe('Company > Emails', () => {
     await expectMail('billing@example.com', 'admin@example.com', 'SMTP connection was successful!');
   });
 });
+
+test.describe('Company > Look and Feel', () => {
+  test('should upload a PNG logo (issue #4)', async ({ page }) => {
+    await loginAdmin(page);
+    await page.goto('/admin/settings/company/lookandfeel/customize/');
+    await handleAccessVerification(page);
+
+    await page.locator('#admin_logo').setInputFiles('assets/blesta-logo-color.png');
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await expectAdminMessage(page, 'The custom logo was successfully updated.');
+  });
+});


### PR DESCRIPTION
Blesta introduced a new check regarding the handling of file uploads, which requires the presence of either `finfo` or `mime_content_type`, which were both not present in this container so far, causing uploads to fail with error messages like `application/octet-stream` being an unsupported MIME type.

This PR adds the missing `phpX-fileinfo` package and also publishes Blesta 5.13.10 to keep the 5.x branch up-to-date. A test has been written as well to avoid this breakage in the future. Lastly, this also ensures that tests run for PRs with an enforceable status check to harden future upgrade procedures.

Closes #4 